### PR TITLE
Update entity query examples to include access checking

### DIFF
--- a/book/entities.md
+++ b/book/entities.md
@@ -51,10 +51,11 @@ more at
 
 ## Query an entity by title and type
 
-This example counts the number of entities of type `article` with the name `$name`. 
+This example counts the number of entities of type `article` with the name `$name`. Note that access checking must be [explicitly specified on content entity queries](https://www.drupal.org/node/3201242).
 
 ```php
 $query = $this->nodeStorage->getQuery()
+  ->accessCheck(FALSE)
   ->condition('type', 'article')
   ->condition('title', $name)
   ->count();

--- a/book/forms.md
+++ b/book/forms.md
@@ -1216,6 +1216,7 @@ public function buildForm(array $form, FormStateInterface $form_state) {
   $nodeStorage = $this->entityTypeManager->getStorage('node');
   // Get i_am_i_want node ids.
   $nids = $nodeStorage->getQuery()
+    ->accessCheck(TRUE)
     ->condition('field_iam', NULL, 'IS NOT NULL')
     ->condition('field_iwant', NULL, 'IS NOT NULL')
     ->condition('field_link', NULL, 'IS NOT NULL')
@@ -1372,6 +1373,7 @@ public function buildForm(array $form, FormStateInterface $form_state) {
   $nodeStorage = $this->entityTypeManager->getStorage('node');
   // Get i_am_i_want node ids.
   $nids = $nodeStorage->getQuery()
+    ->accessCheck(TRUE)
     ->condition('field_iam', NULL, 'IS NOT NULL')
     ->condition('field_iwant', NULL, 'IS NOT NULL')
     ->condition('field_link', NULL, 'IS NOT NULL')
@@ -1475,6 +1477,7 @@ public function submitSelectIam(array $form, FormStateInterface $form_state) {
   // Rebuild the iwant values
   // Get i_am_i_want node ids.
   $nids = $nodeStorage->getQuery()
+    ->accessCheck(TRUE)
     ->condition('type', 'i_am_i_want')
     ->condition('field_iam', $iam_text)
     ->condition('field_iwant', NULL, 'IS NOT NULL')

--- a/book/render.md
+++ b/book/render.md
@@ -336,6 +336,7 @@ use Drupal\Core\Url;
 
 public function build(){
   $result = $this->nodeStorage->getQuery()
+    ->accessCheck(TRUE)
     ->condition('type', 'water_action')
     ->condition('status', '1')
     ->range(0, $this->configuration['block_count'])

--- a/book/services.md
+++ b/book/services.md
@@ -180,6 +180,7 @@ This allows quick access from within your controllers to these services if you n
 $storage = $this->entityTypeManager()->getStorage('node');
 $query = $storage->getQuery();
 $query
+  ->accessCheck(TRUE)
   ->condition('type', 'article')
   ->condition('title', $name)
   ->count();
@@ -481,8 +482,9 @@ So to use this statically, you can use the following:
 $storage = \Drupal::entityTypeManager()->getStorage($entity_type);
 $query = $storage->getQuery();
 $query = \Drupal::entityQuery('node')
- ->condition('type', 'page')
- ->condition('status', 1) ;
+  ->accessCheck(TRUE)
+  ->condition('type', 'page')
+  ->condition('status', 1);
 $nids = $query->execute();
 ```
 
@@ -831,6 +833,7 @@ class DiExamplesController extends ControllerBase {
     $storage = $this->entityTypeManager()->getStorage('node');
     $query = $storage->getQuery();
     $query
+      ->accessCheck(TRUE)
       ->condition('type', 'article')
       ->condition('title', $name)
       ->count();


### PR DESCRIPTION
Per https://www.drupal.org/node/3201242, explicit access checking is needed for content entity queries. Updating examples with `::accessCheck` calls that seem appropriate for the code situation.

Most of them look like they should take into account the current user so I defaulted them to `::accessCheck(TRUE)`. Does that seem right?