### PR TITLE
- fix typo in cron.md

### DIFF
--- a/book/cron.md
+++ b/book/cron.md
@@ -224,14 +224,14 @@ Here is a Drupal cron job on a prod server where it uses a `--resolve` param to
 resolve the IP and the name. This task runs every 15 minutes.
 
 ```
-_/15 _ \* \* \* curl -svo /dev/null http://prod.ddd.test.gov:8080/cron/<key> --resolve prod.ddd.test.gov:8080:201.86.28.12
+*/15 * * * * curl -svo /dev/null http://prod.ddd.test.gov:8080/cron/<key> --resolve prod.ddd.test.gov:8080:201.86.28.12
 ```
 
 ## Resources:
 
 - [Cron automated tasks overview]
 - [Configuring cron jobs using the cron command]
-- [Drupal hook_crom() API]
+- [Drupal hook_cron() API]
 - [Crontab – Quick Reference Running]
 - [Drupal cron tasks from Drush]
 


### PR DESCRIPTION
In [pull request #43](https://github.com/selwynpolit/d9book/pull/43), the text of the link was changed and it broke the link.
I also fixed unnecessary characters in the example.
Before:
![image](https://user-images.githubusercontent.com/90793591/235786062-e891546c-e89d-4094-97bf-7b7ad680fc36.png)
After:
![image](https://user-images.githubusercontent.com/90793591/235786136-f7df8a33-e56d-42ce-8e9e-fe40b36c903e.png)

Check out the changes here - https://maks-oleksyuk.github.io/d9book/cron