### PR TITLE
Initialize default MIME type to prevent undefined variable errors

### DIFF
--- a/book/entities.md
+++ b/book/entities.md
@@ -164,6 +164,10 @@ Note. Drupal is ok with files existing (for example  in sites/default/files)  wi
 Once the file already exists, I write the file entity. I do need a mime type
 
 ```php
+
+// Initialize $mimetype to a default value or a safe fallback
+$mimetype = 'application/octet-stream'; // a general binary mimetype as a fallback
+
 switch (strtoupper($type)){
   case 'PDF':
     $mimetype = 'application/pdf';


### PR DESCRIPTION
Set a default value for `$mimetype` to 'application/octet-stream' to handle cases where `$type` does not match any predefined cases in the switch statement. This ensures that `$mimetype` always has a valid value, preventing potential runtime errors in file operations.