### PR TITLE
Update redirect URL to correct domain

### DIFF
--- a/book/events.md
+++ b/book/events.md
@@ -124,7 +124,7 @@ final class RouteFinishedSubscriber implements EventSubscriberInterface {
    */
   public function onKernelRequest(RequestEvent $event): void {
     if ($this->state->get('system.maintenance_mode')) {
-      $response = new TrustedRedirectResponse('http://www.mytimes.com');
+      $response = new TrustedRedirectResponse('https://www.nytimes.com');
       \Drupal::logger('mymodule')->info("System in maint mode - sent them to the times!");
       $event->setResponse($response);
     }


### PR DESCRIPTION
Change the redirect URL in the RouteFinishedSubscriber from 'http://www.mytimes.com' to 'https://www.nytimes.com'. This correction ensures the redirect points to the intended external site and upgrades the protocol to HTTPS for enhanced security.