### PR TITLE
Remove unused storage variable in paragraphs.md

### DIFF
--- a/book/paragraphs.md
+++ b/book/paragraphs.md
@@ -221,7 +221,6 @@ From
 //Grab the related lessons from the collection.
 $video_collection_node = Node::load($video_collection_nid);
 $lessons = $video_collection_node->field_related_lessons;
-$storage = \Drupal::entityTypeManager()->getStorage('paragraph');
 foreach ($lessons as $lesson) {
   //Load each paragraph and get the nids from them.
   $paragraph = $lesson->entity;


### PR DESCRIPTION
Removed an unused storage variable in the code snippet of "[Load a node and grab a paragraph field to find the nid in an entity reference field](https://www.drupalatyourfingertips.com/paragraphs#load-a-node-and-grab-a-paragraph-field-to-find-the-nid-in-an-entity-reference-field)"