### PR TITLE
Fix selector for noah elements in JavaScript code and remove jQuery-Dependency

### DIFF
--- a/book/javascript.md
+++ b/book/javascript.md
@@ -275,11 +275,11 @@ function general_preprocess_page(&$variables) {
 or using native js `forEach`:
 
 ```js
-(function (Drupal, $) {
+(function (Drupal) {
   Drupal.behaviors.logitworks = {
     attach: function (context, settings) {
 
-      const noah_elements = document.querySelectorAll('#noah');
+      const noah_elements = document.querySelectorAll('.noah');
       noah_elements.forEach(element => {
         // Do something with each element
         element.append('test');
@@ -291,7 +291,7 @@ or using native js `forEach`:
       });
     }
   };
-}) (Drupal, jQuery);
+}) (Drupal);
 ```
 
 ## Set all cards to the same height


### PR DESCRIPTION
In the JavaScript-Example for [Cycle through some elements and add some text or css to them](https://www.drupalatyourfingertips.com/javascript#cycle-through-some-elements-and-add-some-text-or-css-to-them) with **native JS** the dependency for jQuery can be safely removed.
And it would be no Good Practice, if there are more than one element with an `id="#noha"` – therefore i changed the selector to a class.